### PR TITLE
Fix TileRepeater Designer attribute

### DIFF
--- a/src/Samples/Dotnet/TileRepeater_Medium/TileRepeater.Controls/TileRepeater.cs
+++ b/src/Samples/Dotnet/TileRepeater_Medium/TileRepeater.Controls/TileRepeater.cs
@@ -3,7 +3,7 @@ using System.ComponentModel;
 
 namespace WinForms.Tiles
 {
-    [Designer("TileRepeaterDesigner"),
+    [Designer("WinForms.Tiles.Designer.Server.TileRepeaterDesigner"),
      System.ComponentModel.ComplexBindingProperties("DataSource")]
     public partial class TileRepeater : Panel
     {


### PR DESCRIPTION
The [Designer] attribute must contain the whole namespace to get it running correctly. 

```
[Designer("WinForms.Tiles.Designer.Server.TileRepeaterDesigner"),
     System.ComponentModel.ComplexBindingProperties("DataSource")]
    public partial class TileRepeater : Panel
```